### PR TITLE
Request extensions prefs via the background page

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -32,15 +32,22 @@ function injectContentScripts(tabId, opt_callback) {
 
 chrome.extension.onRequest.addListener(
     function(request, sender, callback) {
-        var tabId = request.tabId;
-        injectContentScripts(tabId, callback);
-        if (inspectedTabs.indexOf(tabId) == -1) {
-            chrome.webNavigation.onCommitted.addListener(
-                function(details) {
-                    if (details.tabId == tabId && details.frameId == 0) {
-                        injectContentScripts(tabId);
-                    }
-                });
+        switch(request.command) {
+        case 'injectContentScripts':
+            var tabId = request.tabId;
+            injectContentScripts(tabId, callback);
+            if (inspectedTabs.indexOf(tabId) == -1) {
+                chrome.webNavigation.onCommitted.addListener(
+                    function(details) {
+                        if (details.tabId == tabId && details.frameId == 0) {
+                            injectContentScripts(tabId);
+                        }
+                    });
+            }
             inspectedTabs.push(tabId);
+            return;
+        case 'getAuditPrefs':
+            chrome.storage.sync.get('auditRules', callback);
+            return;
         }
 });

--- a/extension/devtools.js
+++ b/extension/devtools.js
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+if (chrome.devtools.inspectedWindow.tabId)
+    chrome.extension.sendRequest({ tabId: chrome.devtools.inspectedWindow.tabId,
+                                   command: 'injectContentScripts' }, init);
+
 function init(result) {
     if (result && 'error' in result) {
         console.warn('Could not initialise extension:' + result.error);
@@ -35,8 +39,9 @@ function init(result) {
 }
 
 function getAuditPrefs(auditResults) {
-    chrome.storage.sync.get('auditRules',
-                            auditRunCallback.bind(null, auditResults));
+    chrome.extension.sendRequest({ tabId: chrome.devtools.inspectedWindow.tabId,
+                                   command: 'getAuditPrefs' },
+                                 auditRunCallback.bind(null, auditResults));
 }
 
 function auditRunCallback(auditResults, items) {
@@ -86,10 +91,6 @@ function onURLsRetrieved(auditResults, prefs, urls) {
     // Write filled in prefs back to storage
     chrome.storage.sync.set({'auditRules': prefs});
 }
-
-if (chrome.devtools.inspectedWindow.tabId)
-    chrome.extension.sendRequest({ tabId: chrome.devtools.inspectedWindow.tabId,
-                                   command: 'injectContentScripts' }, init);
 
 function handleResults(auditResults, auditRule, severity, frameURL, results, isException) {
     auditResults.resultsPending--;


### PR DESCRIPTION
Requesting chrome.storage from the devtools page only works when devtools is undocked, as per https://code.google.com/p/chromium/issues/detail?id=178618&q=devtools%20process%20docked&colspec=ID%20Pri%20M%20Iteration%20ReleaseBlock%20Cr%20Status%20Owner%20Summary%20OS%20Modified
