### PR TITLE
Fixed URLs in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ git clone --recursive https://github.com/GoogleChrome/accessibility-developer-to
 ```
 
 ## Build
-Download the [http://dl.google.com/closure-compiler/compiler-latest.zip](Closure compiler jar) and put it in ~/src/closure/compiler.jar.
+Download the [Closure compiler jar](http://dl.google.com/closure-compiler/compiler-latest.zip) and put it in ~/src/closure/compiler.jar.
 
 ```
 cd accessibility-developer-tools-extension
@@ -38,7 +38,7 @@ This will run Closure compiler on all the JS sources and place generated outputs
 
 First, you need to enable the "experimental extension APIs" flag on chrome://flags. This will require restarting Chrome to take effect.
 
-The [http://developer.chrome.com/extensions/getstarted.html#unpacked](Chrome extension developer documentation) has the instructions for loading an unpacked extension; `extension` is the the directory containing the manifest, so this should be the directory you load.
+The [Chrome extension developer documentation](http://developer.chrome.com/extensions/getstarted.html#unpacked) has the instructions for loading an unpacked extension; `extension` is the the directory containing the manifest, so this should be the directory you load.
 
 Note: if you already have the web store version of Accessibility Developer Tools, you might want to modify the manifest (`extension/manifest.json`) to display a different name for your local copy. This does not require re-building the project.
 


### PR DESCRIPTION
URLs where in the wrong format for the closure compiler as well as the Chrome instructions for loading an unpacked extension.
